### PR TITLE
Pass job ID to error handlers (#1201)

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -933,6 +933,7 @@ class Worker(object):
             'arguments': job.args,
             'kwargs': job.kwargs,
             'queue': job.origin,
+            'job_id': job.id,
         })
 
         for handler in self._exc_handlers:


### PR DESCRIPTION
The worker handles exceptions in the job outside of the job's own context, so an exception handler / logger cannot call `get_current_job()` to obtain the job ID. The job ID can be used to locate the job in the failed job registry, which allows useful behaviors such as linking to a failed job on a dashboard in an error report.

Closes #1192.