### PR TITLE
bugfix: Add self.serializer when calling self.fetch_many in Job.fetch…

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -440,7 +440,7 @@ class Job(object):
             connection.watch(*self._dependency_ids)
 
         jobs = [job
-                for job in self.fetch_many(self._dependency_ids, connection=self.connection)
+                for job in self.fetch_many(self._dependency_ids, connection=self.connection, serializer=self.serializer)
                 if job]
 
         return jobs


### PR DESCRIPTION
…_dependencies (#1411)

Co-authored-by: Jahn Thomas Fidje <jahn-thomas.fidje@telenor.com>